### PR TITLE
Adding 3D specifics Dataloaders, transforms and model

### DIFF
--- a/medicaltorch/datasets.py
+++ b/medicaltorch/datasets.py
@@ -315,6 +315,7 @@ class MRI2DSegmentationDataset(Dataset):
 
         return data_dict
 
+
 class MRI3DSegmentationDataset(Dataset):
     """This is a generic class for 3D segmentation datasets.
 
@@ -338,8 +339,7 @@ class MRI3DSegmentationDataset(Dataset):
         for input_filename, gt_filename in self.filename_pairs:
             segpair = SegmentationPair2D(input_filename, gt_filename,
                                          self.cache, self.canonical)
-            input_img, gt_img = segpair.get_pair_data()
-            self.handlers.append((input_img, gt_img))
+            self.handlers.append(segpair)
 
     def set_transform(self, transform):
         """This method will replace the current transformation for the
@@ -358,16 +358,13 @@ class MRI3DSegmentationDataset(Dataset):
 
         :param index: slice index.
         """
-        input_img, gt_img = self.handlers[index]
-
+        input_img, gt_img = self.handlers[index].get_pair_data()
         data_dict = {
             'input': input_img,
             'gt': gt_img
         }
-
         if self.transform is not None:
             data_dict = self.transform(data_dict)
-
         return data_dict
 
 class MRI3DLowerVolumeSegmentationDataset(MRI3DSegmentationDataset):
@@ -376,15 +373,22 @@ class MRI3DLowerVolumeSegmentationDataset(MRI3DSegmentationDataset):
         super().__init__(filename_pairs, cache, transform, canonical)
         self.length=length
         self.padding=padding
+        self._prepare_indexes()
 
     def _prepare_indexes(self):
         length = self.length
         padding = self.padding
         for i in range(0, len(self.handlers)):
-            shape = self.handlers[i]
-            for x in range(length[0]+padding, shape[0]-padding, length[0]):
-                for y in range(length[1]+padding, shape[1]-padding, length[1]):
-                    for z in range(length[2]+padding, shape[2]-padding, length[2]):
+            input_img, _ = self.handlers[i].get_pair_data()
+            shape = input_img.shape
+            if (shape[0] - 2 * padding) % length[0] != 0 \
+                    or (shape[1] - 2 * padding) % length[1] != 0 \
+                    or (shape[2] - 2 * padding) % length[2] != 0 :
+                print('Input shape of each dimension should be a multiple of length plus 2 * padding',shape)
+
+            for x in range(length[0]+padding, shape[0]-padding+1, length[0]):
+                for y in range(length[1]+padding, shape[1]-padding+1, length[1]):
+                    for z in range(length[2]+padding, shape[2]-padding+1, length[2]):
                         self.indexes.append({
                             'x_min': x-length[0]-padding,
                             'x_max': x+padding,
@@ -393,23 +397,30 @@ class MRI3DLowerVolumeSegmentationDataset(MRI3DSegmentationDataset):
                             'z_min': z-length[2]-padding,
                             'z_max': z+padding,
                             'handler_index':i})
-                        print(self.indexes[len(self.indexes)-1])
 
     def __len__(self):
         """Return the dataset size."""
         return len(self.indexes)
 
     def __getitem__(self, index):
-        data_dict = super().__getitem__(self.indexes[index]['handler_index'])
-        print(data_dict['input'].shape)
         coord = self.indexes[index]
+        input_img, gt_img = self.handlers[coord['handler_index']].get_pair_data()
+        data_dict = {
+            'input': input_img,
+            'gt': gt_img
+        }
         data_dict['input'] = data_dict['input'][coord['x_min']:coord['x_max'],
-                                                coord['y_min']:coord['y_max'],
-                                                coord['z_min']:coord['z_max']]
+                                coord['y_min']:coord['y_max'],
+                                coord['z_min']:coord['z_max']]
         data_dict['gt'] = data_dict['gt'][coord['x_min']:coord['x_max'],
                                           coord['y_min']:coord['y_max'],
                                           coord['z_min']:coord['z_max']]
 
+        if self.transform is not None:
+            data_dict = self.transform(data_dict)
+
+        data_dict['input'] = data_dict['input'][None,:,:,:]
+        data_dict['gt'] = data_dict['gt'][None,:,:,:]
         return data_dict
 
 

--- a/medicaltorch/models.py
+++ b/medicaltorch/models.py
@@ -264,7 +264,17 @@ class Unet(Module):
 
 
 class UNet3D(nn.Module):
-    #https://arxiv.org/pdf/1606.06650.pdf
+    """A reference of 3D U-Net model.
+
+    Implementation origin :
+    https://github.com/shiba24/3d-unet/blob/master/pytorch/model.py
+
+    .. seealso::
+        Özgün Çiçek, Ahmed Abdulkadir, Soeren S. Lienkamp, Thomas Brox
+        and Olaf Ronneberger (2016). 3D U-Net: Learning Dense Volumetric
+        Segmentation from Sparse Annotation
+        ArXiv link: https://arxiv.org/pdf/1606.06650.pdf
+    """
     def __init__(self, in_channel, n_classes):
         self.in_channel = in_channel
         self.n_classes = n_classes

--- a/medicaltorch/models.py
+++ b/medicaltorch/models.py
@@ -198,11 +198,11 @@ class DownConv(Module):
 class UpConv(Module):
     def __init__(self, in_feat, out_feat, drop_rate=0.4, bn_momentum=0.1):
         super(UpConv, self).__init__()
-        self.up1 = nn.Upsample(scale_factor=2, mode='bilinear')
+        self.up1 = nn.functional.interpolate
         self.downconv = DownConv(in_feat, out_feat, drop_rate, bn_momentum)
 
     def forward(self, x, y):
-        x = self.up1(x)
+        x = self.up1(x, scale_factor=2, mode='bilinear', align_corners=True)
         x = torch.cat([x, y], dim=1)
         x = self.downconv(x)
         return x
@@ -258,7 +258,7 @@ class Unet(Module):
         x10 = self.up3(x9, x1)
 
         x11 = self.conv9(x10)
-        preds = F.sigmoid(x11)
+        preds = torch.sigmoid(x11)
 
         return preds
 

--- a/medicaltorch/transforms.py
+++ b/medicaltorch/transforms.py
@@ -160,14 +160,12 @@ class CenterCrop2D(MTTransform):
         self.propagate_params(sample, params)
 
         input_data = F.center_crop(input_data, self.size)
-        #input_data = F.resize(input_data, 64)
         rdict['input'] = input_data
 
         if self.labeled:
             gt_data = sample['gt']
             gt_metadata = sample['gt_metadata']
             gt_data = F.center_crop(gt_data, self.size)
-            #gt_data = F.resize(gt_data, 64)
             gt_metadata["__centercrop"] = (fh, fw, w, h)
             rdict['gt'] = gt_data
 

--- a/medicaltorch/transforms.py
+++ b/medicaltorch/transforms.py
@@ -235,7 +235,27 @@ class NormalizeInstance(MTTransform):
         sample.update(rdict)
         return sample
 
+class NormalizeInstance3D(MTTransform):
+    """Normalize a tensor image with mean and standard deviation estimated
+    from the sample itself.
 
+    :param mean: mean value.
+    :param std: standard deviation value.
+    """
+    def __call__(self, sample):
+        input_data = sample['input']
+
+        mean, std = input_data.mean(), input_data.std()
+
+        if mean != 0 or std != 0:
+            input_data_normalized = F.normalize(input_data, [mean for _ in range(0,input_data.shape[0])], [std for _ in range(0,input_data.shape[0])])
+
+            rdict = {
+                'input': input_data_normalized,
+            }
+            sample.update(rdict)
+        return sample
+        
 class RandomRotation(MTTransform):
     def __init__(self, degrees, resample=False,
                  expand=False, center=None,


### PR DESCRIPTION
This version contains some necessary functions to make a simple pipeline to train and use a 3D U-Net model.

This version contains :
- 2 data loaders (MRI3DSegmentationDataset, MRI3DSubVolumeSegmentationDataset), the first one just return the images/gt as tensors (the whole volume). The second one split the volume into several subelements, which is necessary to run U-Net 3D without using dozens of VRAM Go.
- New transforms (NormalizeInstance3D, RandomRotation3D, RandomReverse3D).
- A 3D U-Net model
- Also updated some deprecated functions usage in the U-Net model